### PR TITLE
Add custom icon for public dashboards requiring authentication

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="WireCloud" name="workspace-browser" version="0.1.3">
+<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="WireCloud" name="workspace-browser" version="0.1.4a1">
     <details>
         <title>__MSG_displayName__</title>
         <homepage>https://github.com/Wirecloud/workspace-browser-widget</homepage>

--- a/src/doc/changelog.md
+++ b/src/doc/changelog.md
@@ -1,3 +1,9 @@
+## v0.1.4 (XXXX/XX/XX)
+
+- Add custom icon for public dashboards requiring authentication (requires
+    WireCloud 1.4).
+
+
 ## v0.1.3 (2019/05/23)
 
 - Add i18n feature

--- a/src/js/WorkspaceBrowser.js
+++ b/src/js/WorkspaceBrowser.js
@@ -183,7 +183,9 @@
                     visibility: function (options) {
                         var element = document.createElement('i');
                         element.className = "fa fa-fw fa-2x";
-                        if (workspace.public) {
+                        if (workspace.public && workspace.requireauth) {
+                            element.classList.add('fa-id-card');
+                        } else if (workspace.public) {
                             element.classList.add('fa-globe');
                         } else if (workspace.shared) {
                             element.classList.add('fa-share-alt');


### PR DESCRIPTION
WireCloud 1.4 will have support for public dashboards requiring authentication (disallowing anonymous users), see Wirecloud/wirecloud#428 for more details. This PR adds a new icon for those dashboards.